### PR TITLE
Improve PS/2 Key Up Handling

### DIFF
--- a/Programs/asm/invaders.asm
+++ b/Programs/asm/invaders.asm
@@ -568,12 +568,15 @@ KeyHandler:     INK CPI 0xff BEQ key_rts
 isa:            LDA pressed STA left ORI 1 STA pressed CLB right RTS
 isspace:        LDA pressed STA fire ORI 1 STA pressed RTS
 isd:            LDA pressed STA right ORI 1 STA pressed CLB left RTS
-release:        LDI 0
-  key_wait:     NOP NOP NOP NOP NOP INC BCC key_wait         ; wait 3.8ms for datagram following 0xf0
-                INK CPI 0xff BEQ key_rts										 ; no 2nd datagram -> avoid
-                  CLB pressed JPA key_entry									 ; released key was received -> analyze it
+release:        LDI 0 STA released_cntr
+  key_wait:		INK CPI 0xff BNE key_release
+  				NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP		; wait for key up datagram
+  				NOP NOP NOP
+  				INB released_cntr CPI 0 BNE key_wait
+  				JPA key_rts									; no 2nd datagram -> avoid
+  key_release:  CLB pressed JPA key_entry					; released key was received -> analyze it
 pressed:        1
-
+released_cntr:	0
 ; print number 000 - 999 +  '0'
 ; push: number_lsb, number_msb
 ; pull: #, #

--- a/Programs/asm/os.asm
+++ b/Programs/asm/os.asm
@@ -831,11 +831,8 @@ OS_ScanPS2:       INK CPI 0xff BEQ key_rts                     ; fast readout of
   key_ptrok:          LDI 0x01 BNK LDA                         ; switch to PS2 table in FLASH
   ps2_ptr:            0xffff STA ps2_ascii                     ; read table data from FLASH memory and store ASCII code
                       BFF RTS                                  ; do not use A so that this routine can be called often without processing key immediately
-  key_release:    LDI 0x01 STA ps2_release                     ; IMPROVED PS2 RELEASE DETECTION - WORKS GREAT!
-                  LDI 0
-    key_wait:     NOP NOP NOP NOP NOP INC BCC key_wait         ; wait 4.6ms for next datagram
-                    INK CPI 0xff BNE key_reentry               ; treat the actual key, too
-                      JPA key_clearrel                         ; ignore this 0xf0. We have missed it's datum.
+  key_release:    LDI 0x01 STA ps2_release                     ; IMPROVED PS2 RELEASE DETECTION - WORKS GREATER!
+  key_release_w8: INK CPI 0xff BEQ key_release_w8 JPA key_reentry
   key_shift:      LDA ps2_release NEG STA ps2_shift
                       JPA key_clearrel
   key_alt:        LDA ps2_release NEG STA ps2_alt

--- a/Programs/asm/os.asm
+++ b/Programs/asm/os.asm
@@ -832,7 +832,12 @@ OS_ScanPS2:       INK CPI 0xff BEQ key_rts                     ; fast readout of
   ps2_ptr:            0xffff STA ps2_ascii                     ; read table data from FLASH memory and store ASCII code
                       BFF RTS                                  ; do not use A so that this routine can be called often without processing key immediately
   key_release:    LDI 0x01 STA ps2_release                     ; IMPROVED PS2 RELEASE DETECTION - WORKS GREATER!
-  key_release_w8: INK CPI 0xff BEQ key_release_w8 JPA key_reentry
+                    LDI 0 STA ps2_wait_cntr
+    key_wait:       INK CPI 0xff BNE key_reentry
+                    NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP    
+                    NOP NOP NOP                                ; slow down wait loop
+                    INB ps2_wait_cntr CPI 0 BNE key_wait
+                    JPA key_clearrel                           ; ignore this 0xf0. We have missed it's datum
   key_shift:      LDA ps2_release NEG STA ps2_shift
                       JPA key_clearrel
   key_alt:        LDA ps2_release NEG STA ps2_alt
@@ -846,6 +851,8 @@ OS_ScanPS2:       INK CPI 0xff BEQ key_rts                     ; fast readout of
   ps2_alt:        0xff
   ps2_release:    0xff
   ps2_ascii:      0x00                                         ; store "pressed" key code here
+  ps2_wait_cntr:  0x00
+
 
 ; --------------------------------------------------------------------------------------------
 ; Resets the state of keys ALT, SHIFT, CTRL to avoid lock-up after a longer operation (CTRL+V)


### PR DESCRIPTION
This change uses a detection loop to determine when the key up datagrams is sent rather than trying to use precise timing. This will better handle keyboards that have a longer delay between the key up indicator `0xF0` and the key datagram than th original 4.2 ms assumption.